### PR TITLE
Allow per-receiver depth

### DIFF
--- a/place_receivers/README.md
+++ b/place_receivers/README.md
@@ -39,6 +39,13 @@ place_receivers -d DEPTH -r RECEIVERS -m MESH -o OUTPUT
 7.794138e+05 5.097186e+05
 </pre>
 
+One may specify the depth per receiver with an optional third column, where the depth is the maximum of DEPTH and the third column. For example with DEPTH=0.1:
+
+<pre>
+8.251411e+05 5.900044e+05 0.0   # -> depth 0.1
+7.654161e+05 3.274531e+05 100.0 # -> depth 100
+</pre>
+
 - MESH is the file name of the mesh.
 - OUTPUT is the file name of the output file.
 

--- a/place_receivers/src/Geometry.cpp
+++ b/place_receivers/src/Geometry.cpp
@@ -41,6 +41,7 @@
 #include "Geometry.h"
 
 #include <limits>
+#include <cmath>
 
 #ifdef USE_NETCDF
 int const FACE2NODES[4][3] = {{0, 2, 1}, {0, 1, 3}, {0, 3, 2}, {1, 2, 3}};
@@ -109,11 +110,15 @@ struct Action {
     }
     
     if (inside) {
+      double local_depth = 0.0;
+      if (!std::isnan(receiver.z)) {
+        local_depth = std::max(depth, std::fabs(receiver.z));
+      }
       receiver.z = (faceDist - faceNormal[0] * receiver.x - faceNormal[1] * receiver.y) / faceNormal[2];
       if (faceNormal[2] >= 0) {
-        receiver.z -= depth;
+        receiver.z -= local_depth;
       } else {
-        receiver.z += depth;
+        receiver.z += local_depth;
       }
     }
   }

--- a/place_receivers/src/Reader.cpp
+++ b/place_receivers/src/Reader.cpp
@@ -58,9 +58,11 @@ std::vector<Point> readReceiverFile(std::string const& fileName) {
 
   while (std::getline(in, line)) {
     std::istringstream iss(line);
-    Point p;
-    iss >> p.x >> p.y;
-    p.z = NAN;
+    Point p{NAN, NAN, NAN};
+    int coord = 0;
+    while (coord < 3 && iss.good()) {
+      iss >> p.coords[coord++];
+    }
     locations.push_back(p);
     if (iss.bad()) {
       std::cerr << "An error occurred while reading the receiver file." << std::endl;
@@ -73,16 +75,19 @@ std::vector<Point> readReceiverFile(std::string const& fileName) {
 
 void writeReceiverFile(KDTree const& tree, std::string const& fileName) {
   std::ofstream out(fileName.c_str());
-  out << std::scientific << std::setprecision(10);
+  out << std::scientific << std::setprecision(16);
   
   int failureCounter = 0;
   Point const* points = tree.points();
+  std::vector<Point> sortedPoints(tree.numPoints());
   for (unsigned p = 0; p < tree.numPoints(); ++p) {
-    Point const* point = &points[tree.index(p)];
-    if (!std::isnan(point->z)) {
-      out << point->x << " " << point->y << " " << point->z << std::endl;
+    sortedPoints[tree.index(p)] = points[p];
+  }
+  for (auto const& point : sortedPoints) {
+    if (!std::isnan(point.z)) {
+      out << point.x << " " << point.y << " " << point.z << std::endl;
     } else {
-      std::cerr << "Warning: Did not find elevation for receiver at (" << point->x << ", " << point->y << ")." << std::endl;
+      std::cerr << "Warning: Did not find elevation for receiver at (" << point.x << ", " << point.y << ")." << std::endl;
       ++failureCounter;
     }
   }


### PR DESCRIPTION
+ Allows an optional third column, in which a per-receiver depth may be specified.
+ Fixes bug such that receivers are not in the same order as in input file.