### PR TITLE
fix non-isotropic mesh in create_fault_from_trace.py

### DIFF
--- a/creating_geometric_models/create_fault_from_trace.py
+++ b/creating_geometric_models/create_fault_from_trace.py
@@ -106,12 +106,10 @@ def generate_vertices_dip_vary_along_dip(maxdepth, sign=1):
     # compute depth array
     current_depth = 0.0
     depth = []
-    while True:
+    while current_depth <= maxdepth:
         depth.append(current_depth)
         current_depth += dx * sin(dipangle(-sign * current_depth))
-        if current_depth > maxdepth:
-            depth = np.array(depth)
-            break
+    depth = np.array(depth)
     nd = depth.shape[0]
     vertices = np.zeros((nx, nd, 3))
     vertices[:, 0, :] = nodes


### PR DESCRIPTION
The meshing script create_fault_from_trace.py was generating meshes that are not isotropic for dip !=90.
The mesh size was larger along dip than along strike.
While this is not a big problem, it might become problematic when incorporating roughness to low dipping faults
(using a derived script that is not yet ready for getting published).
Therefore I've fixed this issue for dipType=0 and 1.
(as this would not look nice for dipType=2,  with a along-strike varying dip).
Here is an illustration with along-depth dip variations and very shallow dip at depth:
(old vs new)
![old_vs_new](https://user-images.githubusercontent.com/13536910/134341662-24952c94-0590-41a6-a1df-44bf095d27ab.png)
