### PR TITLE
allow negative dip (by avoiding negative dimension array)

### DIFF
--- a/creating_geometric_models/create_fault_from_trace.py
+++ b/creating_geometric_models/create_fault_from_trace.py
@@ -68,7 +68,7 @@ def generate_vertices_constant_dip(maxdepth, sign=1):
     extends 2d fault trace (nodes array) along constant dip
     returns a 3d array of vertices coordinates
     """
-    nd = int(maxdepth / (sin(dip) * dx))
+    nd = int(maxdepth / (sin(np.abs(dip)) * dx))
     vertices = np.zeros((nx, nd, 3))
     vertices[:, 0, :] = nodes
     one_over_tan_dip = 1.0 / tan(dip)


### PR DESCRIPTION
Sometimes, we may need to dip the fault to the other direction (and therefore to a negative value)
(the other option would be to flip the trace nodes array).
I made this possible by adding an absolute value to the dip.

Thomas.