### PR TITLE
Fix C++ version for PUML to compile again.

### DIFF
--- a/place_receivers/CMakeLists.txt
+++ b/place_receivers/CMakeLists.txt
@@ -5,7 +5,7 @@ project(place_receivers LANGUAGES C CXX)
 set(LOG_LEVEL "info" CACHE STRING "Log level for the code")
 set_property(CACHE LOG_LEVEL PROPERTY STRINGS "debug" "info" "warning" "error")
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS


### PR DESCRIPTION
This merely bumps up the C++ version needed by Cmake from C++11 to C++17, since PUML now uses language features from that version.