### PR TITLE
Make `place_receivers` work with large meshes

### DIFF
--- a/place_receivers/src/Reader.cpp
+++ b/place_receivers/src/Reader.cpp
@@ -115,8 +115,8 @@ Mesh::Mesh(std::string const& fileName){
   puml.addData((fileName + ":/boundary").c_str(), PUML::CELL);
 
 
-  int nElements = puml.numOriginalCells();
-  int nVertex = puml.numOriginalVertices();
+  size_t nElements = puml.numOriginalCells();
+  size_t nVertex = puml.numOriginalVertices();
   elementVertices = new int[nElements*4];
   vertexCoordinates = new double[nVertex*3];
   elementBoundaries = new int[nElements*4];


### PR DESCRIPTION
Maybe helps with #50.

The reason for the PR is: if we have a mesh as sized as in #50 (about 684 mln cells), then 4 * 684 exceeds 2.14 bln which is the maximum number that is supported by a signed 32-bit integer. We've not encountered this issue so far, since a mesh of size e.g. 518 mln (Palu) will be below 2.14 bln, even when multiplied by 4.